### PR TITLE
Remove URL from package description

### DIFF
--- a/tumblesocks-pkg.el
+++ b/tumblesocks-pkg.el
@@ -1,5 +1,5 @@
 (define-package "tumblesocks" "0.0.3"
-  "An Emacs tumblr client. See http://github.com/gcr/tumblesocks"
+  "An Emacs tumblr client"
   '((htmlize "1.39")
     (oauth "1.0.3")
     (markdown-mode "1.8.1")))


### PR DESCRIPTION
Embedding the URL in the package description makes for clunky package lists on Melpa and in `M-x package-list-packages`. This commit removes the URL, keeping with the convention of using a single short sentence for the package description.
