### PR TITLE
Add a defcustom to have new posts queued by default

### DIFF
--- a/tumblesocks-user.el
+++ b/tumblesocks-user.el
@@ -3,6 +3,15 @@
 (require 'tumblesocks-api)
 (provide 'tumblesocks-user)
 
+(defcustom tumblesocks-post-default-state 'published
+  "Change the default state of your newly created posts"
+  :type '(choice (const :tag "Published" 'published)
+                 (const :tag "Draft" 'draft)
+                 (const :tag "Queue" 'queue)
+                 (const :tag "Private" 'private))
+  :group 'tumblesocks)
+
+
 (defun tumblesocks-follow-blog (blog)
   "Follow the given Tumblr blog"
   (interactive "sTumblr blog to follow (URL): ")
@@ -30,6 +39,7 @@
   (let ((args (append
                `(:type "text"
                  :format "markdown"
+                 :state ,tumblesocks-post-default-state
                  :body ,(buffer-substring begin end)
                  :title ,title)
                (and tags `(:tags ,tags)))))


### PR DESCRIPTION
I usually queue all my new posts, so I've added the state parameter into `tumblesocks-text-post-from-region`. It shouldn't change anything unless you manually go in and change `tumblesocks-default-post-state` to something other than `published`.
