### PR TITLE
Add Post state options - Fixes #5

### DIFF
--- a/tumblesocks-user.el
+++ b/tumblesocks-user.el
@@ -15,8 +15,8 @@
 
 (defun tumblesocks-get-post-state (&optional state)
   (interactive)
-  (if (or (string= tumblesocks-post-default-state "Ask")
-          (string= state "Ask"))
+  (if (or (string= (downcase tumblesocks-post-default-state) "ask")
+          (string= (downcase state) "ask"))
       (completing-read "State: "
                        '("published"
                          "draft"


### PR DESCRIPTION
From https://github.com/gcr/tumblesocks/issues/5 
- Add "ask" as an option for post state; if "ask" is chosen, creating a post asks user to choose one of the allowed post states: published, draft, private, queue, or schedule
- Add "schedule" as an option for post state; if "schedule" is chosen, :state is set to "queue" and user is queried for a publish time. I don't really have any clue how Tumblr interprets the publish time text - during testing, things like "tomorrow, 5pm" worked, but I'm pretty sure you could also specify a fully specified time. See [tumblr's docs](http://www.tumblr.com/docs/en/advanced_post_options#schedule) to figure out what Tumblr accepts for the "Publish On" field. Posts created with "schedule" state can be found in the queue.
