### PR TITLE
Use strings instead of quoted symbols for post state - fixes #8

### DIFF
--- a/tumblesocks-user.el
+++ b/tumblesocks-user.el
@@ -3,14 +3,14 @@
 (require 'tumblesocks-api)
 (provide 'tumblesocks-user)
 
-(defcustom tumblesocks-post-default-state 'published
+(defcustom tumblesocks-post-default-state "published"
   "Change the default state of your newly created posts"
-  :type '(choice (const :tag "Published" 'published)
-                 (const :tag "Draft" 'draft)
-                 (const :tag "Queue" 'queue)
-                 (const :tag "Private" 'private)
-                 (const :tag "Schedule" 'schedule)
-                 (const :tag "Ask" 'ask))
+  :type '(choice (const :tag "Published" "published")
+                 (const :tag "Draft" "draft")
+                 (const :tag "Queue" "queue")
+                 (const :tag "Private" "private")
+                 (const :tag "Schedule" "schedule")
+                 (const :tag "Ask" "ask"))
   :group 'tumblesocks)
 
 (defun tumblesocks-get-post-state (&optional state)


### PR DESCRIPTION
I was under the mistaken impression that 'published == "published" all the time. It does seem to satisfy string=, but it will throw type errors in other places, like mentioned in #8 . So, I think what I'm supposed to do is use strings and include a nil check. Hopefully I'm not just spinning in circles here :) 
