### PR TITLE
Add License library header

### DIFF
--- a/tumblesocks.el
+++ b/tumblesocks.el
@@ -4,6 +4,7 @@
 
 ;; Author: gcr <gcr@sneakygcr.net>
 ;; URL: http://github.com/gcr/tumblesocks
+;; License: as-is
 
 (defgroup tumblesocks nil
   "Emacs tumblr client"


### PR DESCRIPTION
This helps tools such as those used by the Emacsmirror and Melpa which
expect to find this information here.  The COPYING file would also
work, but only if its contents match a well-known license, which isn't
the case here.