### PR TITLE
See my issue #26, these are my fixes from my v1.1 at https://codeberg.org/gargle/tumblesocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,27 @@
 tumblesocks - un-break it fork
 ==============================
 
-`tumblesocks.el` old, crazy, messy, awesome, abandoned, and broken, and it depends on `emacs-oauth`, which is much the same. each file has about 70 `flycheck` errors in it. but it also fucking rocks.
+`tumblesocks.el` old, crazy, messy, awesome, abandoned, and broken, and it depends on `emacs-oauth`,
+which is much the same. each file has about 70 `flycheck` errors in it.  But it also fucking rocks.
 
-so this repo adds patches that people have shared online for un-breaking `tumblesocks.el`.
+So this repo adds patches that people have shared online for un-breaking `tumblesocks.el`.
 
-a patched version of ye olde `emacs-oauth` is also needed. it's here: https://codeberg.org/martianh/emacs-oauth.
+A patched version of ye olde `emacs-oauth` is also needed.  It's here: https://codeberg.org/martianh/emacs-oauth.
 
-i haven't actually tried this out yet, i have just patched changes from my `init.el` to these two repos. if you try these out, i'd recommend you remove all trace of any other versions.
+If you try these out, I'd recommend you remove all trace of any other versions.
 
-further patches welcome.
+Further patches are most welcome.
 
-original readme
+
+
+Modified README
 ===============
 
 `tumblesocks-mode` - Tumblr Support for Emacs
 =============================================
 <!-- ![http://i.imgur.com/WW6Qo.png](http://i.imgur.com/WW6Qo.png) -->
+This is how tumblesocks looks now:
+
 ![http://i.imgur.com/9wroS.png](http://i.imgur.com/9wroS.png)
 
 Tumblesocks is an Emacs tumblr client. With it, you can write posts,

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Modified README
 <!-- ![http://i.imgur.com/WW6Qo.png](http://i.imgur.com/WW6Qo.png) -->
 This is how tumblesocks looks now:
 
-![http://i.imgur.com/9wroS.png](http://i.imgur.com/9wroS.png)
+![https://i.ibb.co/9WYG2mB/xwd.jpg](https://i.ibb.co/9WYG2mB/xwd.jpg)
 
 Tumblesocks is an Emacs tumblr client. With it, you can write posts,
 check your dashboard, and view blogs and notes.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+
+tumblesocks - un-break it fork
+==============================
+
+`tumblesocks.el` old, crazy, messy, awesome, abandoned, and broken, and it depends on `emacs-oauth`, which is much the same. each file has about 70 `flycheck` errors in it. but it also fucking rocks.
+
+so this repo adds patches that people have shared online for un-breaking `tumblesocks.el`.
+
+a patched version of ye olde `emacs-oauth` is also needed. it's here: https://codeberg.org/martianh/emacs-oauth.
+
+i haven't actually tried this out yet, i have just patched changes from my `init.el` to these two repos. if you try these out, i'd recommend you remove all trace of any other versions.
+
+further patches welcome.
+
+original readme
+===============
+
 `tumblesocks-mode` - Tumblr Support for Emacs
 =============================================
 <!-- ![http://i.imgur.com/WW6Qo.png](http://i.imgur.com/WW6Qo.png) -->

--- a/tumblesocks-api.el
+++ b/tumblesocks-api.el
@@ -66,10 +66,10 @@ call `tumblesocks-api-reauthenticate' after this."
           (if (string-match "\\([^:]*\\):\\(.*\\)"
                             (buffer-substring (point-min) (point-max)))
               (setq tumblesocks-token
-                    (make-oauth-access-token
+                    (oauth-access-token--create
                      :consumer-key tumblesocks-consumer-key
                      :consumer-secret tumblesocks-secret-key
-                     :auth-t (make-oauth-t
+                     :auth-t (oauth-t--create
                               :token (match-string 1 str)
                               :token-secret (match-string 2 str))))))
         (kill-this-buffer)))

--- a/tumblesocks-api.el
+++ b/tumblesocks-api.el
@@ -1,5 +1,6 @@
 ;; tumblesocks-api.el -- functions for talking with tumblr
 ;; Copyright (C) 2012 gcr
+;; Copyright (C) 2023 gargle
 
 (require 'oauth)
 (require 'json)

--- a/tumblesocks-user.el
+++ b/tumblesocks-user.el
@@ -85,3 +85,6 @@ the user what to do for each post."
   "Create a new Tumblr markdown text post from the current buffer, returning the ID and copying the URL to the clipboard."
   (interactive "sTitle: \nsTags (optional, comma separated): ")
   (tumblesocks-text-post-from-region (point-min) (point-max) title tags))
+
+(provide 'tumblesocks-user)
+;;; tumblesocks-user.el ends here

--- a/tumblesocks-view.el
+++ b/tumblesocks-view.el
@@ -358,15 +358,13 @@ better suited to inserting each post."
     (setq begin (point))
     (insert blog_name)
     ;; Title
-    (insert " ")
     (cond
-     (title (tumblesocks-view-insert-html-fragment title))
-     ;;(caption (tumblesocks-view-insert-html-fragment caption t))
-     ;;(question (tumblesocks-view-insert-html-fragment question t))
-     (t (insert " ")))
+     (title (if (not (string= title ""))
+                (insert " : " title))))
     (setq end_bname (point))
     (put-text-property begin end_bname 'face (list '(:weight bold) 'highlight))
     ;; Date
+    (insert "\n")
     (insert (format-time-string "%c" (date-to-time date)))
     (insert " ")
     ;; Notes

--- a/tumblesocks-view.el
+++ b/tumblesocks-view.el
@@ -357,15 +357,18 @@ better suited to inserting each post."
   (let (begin end_bname)
     (setq begin (point))
     (insert blog_name)
-    (setq end_bname (point))
-    (put-text-property begin end_bname 'face (list '(:weight bold) 'highlight))
     ;; Title
     (insert " ")
     (cond
-     (title (tumblesocks-view-insert-html-fragment title t))
+     (title (tumblesocks-view-insert-html-fragment title))
      ;;(caption (tumblesocks-view-insert-html-fragment caption t))
      ;;(question (tumblesocks-view-insert-html-fragment question t))
      (t (insert " ")))
+    (setq end_bname (point))
+    (put-text-property begin end_bname 'face (list '(:weight bold) 'highlight))
+    ;; Date
+    (insert (format-time-string "%c" (date-to-time date)))
+    (insert " ")
     ;; Notes
     (when (and note_count (> note_count 0))
       (insert " (" (format "%d" note_count) " note"

--- a/tumblesocks-view.el
+++ b/tumblesocks-view.el
@@ -665,7 +665,7 @@ You can browse around, edit, and delete posts from here.
   (tumblesocks-view-prepare-buffer
    (concat "Tag search: " tag))
   (tumblesocks-view-render-blogdata
-   (tumblesocks-api-tagged tag nil nil "html")
+   (tumblesocks-api-tagged tag nil nil "raw")
    0) ; don't allow them to browse next (this isn't possible in general anyways)
   (tumblesocks-view-finishrender)
   (setq tumblesocks-view-refresh-action

--- a/tumblesocks-view.el
+++ b/tumblesocks-view.el
@@ -1,5 +1,8 @@
 ;; tumblesocks-view.el -- Provide an interface to view tumblr blog posts.
 
+;; Copyright 2012 gcr
+;; Copyright 2023 gargle
+
 (eval-when-compile
   (require 'easymenu))
 

--- a/tumblesocks-view.el
+++ b/tumblesocks-view.el
@@ -205,7 +205,7 @@ This causes Tumblesocks to ignore the setting of
   "Renders and inserts an HTML sexp. If inline is t, then <p> tags will have no effect."
   (let ((shr-width nil))
     (if inline
-        (flet ((shr-ensure-paragraph () 0))
+        (cl-flet ((shr-ensure-paragraph () 0)) ; cl-flet
           ;; disable newlines, for now ...
           (condition-case nil
               ;; this must go in the flet, sorry!
@@ -214,6 +214,7 @@ This causes Tumblesocks to ignore the setting of
       (condition-case nil
           (shr-insert-document html-frag-parsed)
         (error (message "Couldn't insert HTML."))))))
+
 (defun tumblesocks-view-insert-html-fragment (html-fragment &optional inline)
   "Renders and inserts an HTML fragment. If inline is t, then <p> tags will have no effect."
   (let (html-frag-parsed)
@@ -547,42 +548,43 @@ You can browse around, edit, and delete posts from here.
 (defun tumblesocks-view-render-notes (notes)
   "Render the given notes into the current buffer."
   (let ((start (point)))
-    (flet ((comment-that ()
-              (put-text-property start (point) 'face font-lock-comment-face)
-              (setq start (point)))
-           (bold-that ()
-              (put-text-property start (point) 'face
-                                 (cons '(:weight bold) font-lock-comment-face))
-              (setq start (point))))
+    (cl-flet ((comment-that ()
+                            (put-text-property start (point) 'face font-lock-comment-face)
+                            (setq start (point)))
+              (bold-that ()
+                         (put-text-property start (point) 'face
+                                            (cons '(:weight bold) font-lock-comment-face))
+                         (setq start (point))))
       (insert "-- Notes:\n")
       (comment-that)
       (dolist (note notes)
-        (tumblesocks-bind-plist-keys note
-           (type post_id blog_name blog_url reply_text answer_text added_text)
-           (cond ((string= type "posted")
-                  (insert blog_name " posted this"))
-                 ((string= type "answer")
-                  (insert blog_name " answers:\n  ")
-                  (comment-that)
-                  (tumblesocks-view-insert-html-fragment answer_text t)
-                  (bold-that))
-                 ((string= type "reblog")
-                  (insert blog_name " reblogged this on " blog_url))
-                 ((string= type "like")
-                  (insert blog_name " liked this"))
-                 ((string= type "reply")
-                  (insert blog_name " says: ")
-                  (comment-that)
-                  (tumblesocks-view-insert-html-fragment reply_text t)
-                  (bold-that))
-                 (t (insert (format "%S" note))))
-           (when added_text
-             (insert "\n  ")
-             (comment-that)
-             (insert added_text)
-             (bold-that))
-           (insert "\n")
-           (comment-that))))))
+        (tumblesocks-bind-plist-keys
+         note
+         (type post_id blog_name blog_url reply_text answer_text added_text)
+         (cond ((string= type "posted")
+                (insert blog_name " posted this"))
+               ((string= type "answer")
+                (insert blog_name " answers:\n  ")
+                (comment-that)
+                (tumblesocks-view-insert-html-fragment answer_text t)
+                (bold-that))
+               ((string= type "reblog")
+                (insert blog_name " reblogged this on " blog_url))
+               ((string= type "like")
+                (insert blog_name " liked this"))
+               ((string= type "reply")
+                (insert blog_name " says: ")
+                (comment-that)
+                (tumblesocks-view-insert-html-fragment reply_text t)
+                (bold-that))
+               (t (insert (format "%S" note))))
+         (when added_text
+           (insert "\n  ")
+           (comment-that)
+           (insert added_text)
+           (bold-that))
+         (insert "\n")
+         (comment-that))))))
 
 (defun tumblesocks-view-like-post-at-point (like-p)
   "Like the post underneath point. With prefix arg (C-u), unlike it."
@@ -618,7 +620,7 @@ You can browse around, edit, and delete posts from here.
 (defun tumblesocks-view-posts-tagged (tag)
   "Search for posts with the given tag."
   (interactive (list (read-from-minibuffer
-                      "Search for posts with tag: " 
+                      "Search for posts with tag: "
                       (tumblesocks-view--dwim-at-point))))
   (tumblesocks-view-prepare-buffer
    (concat "Tag search: " tag))
@@ -656,7 +658,7 @@ You can browse around, edit, and delete posts from here.
      :help "Move to the previous post."]
     "--"
     ["Search" tumblesocks-view-posts-tagged
-     :help "Search for posts with a certain tag."]    
+     :help "Search for posts with a certain tag."]
     ["Refresh List" tumblesocks-view-refresh
      :help "Refresh the current view (download new posts)."]
     "---"
@@ -666,3 +668,6 @@ You can browse around, edit, and delete posts from here.
      :help "tumblesocks-mode settings"]
     ["Quit" quit-window
      :help "Close the current frame"]))
+
+(provide 'tumblesocks-view)
+;;; tumblesocks-view.el ends here

--- a/tumblesocks.el
+++ b/tumblesocks.el
@@ -4,7 +4,7 @@
 ;; Copyright 2023 gargle
 
 ;; Author: gcr <gcr@sneakygcr.net>
-;;         gargle <johan.laenen+tumblesocks@gmail.com>
+;;         gargle <johan.laenen+codeberg@gmail.com>
 ;; URL: http://github.com/gcr/tumblesocks
 ;;      https://codeberg.org/gargle/tumblesocks
 ;; License: zlib

--- a/tumblesocks.el
+++ b/tumblesocks.el
@@ -1,9 +1,12 @@
 ;;; tumblesocks.el --- An Emacs tumblr client.
 
 ;; Copyright 2012 gcr
+;; Copyright 2023 gargle
 
 ;; Author: gcr <gcr@sneakygcr.net>
+;;         gargle <johan.laenen+tumblesocks@gmail.com>
 ;; URL: http://github.com/gcr/tumblesocks
+;;      https://codeberg.org/gargle/tumblesocks
 ;; License: zlib
 
 (defgroup tumblesocks nil


### PR DESCRIPTION
I forked https://codeberg.org/martianh/tumblesocks into https://codeberg.org/gargle/tumblesocks and made some changes to your code to make it work with oauth again. I also changed the layout, added #tags to posts, and I added a 'tumblesocks-view-notifications'. I added a copyright comment in tumblesocks.el, tumblesocks-api.el, and tumblesocks-view.el with my handle 'gargle' and I added myself as an 'author' in tumblesocks.el.

Everything seems to work so I tagged my changes as v1.1 and 'released' them on codeberg.org. I merged my changes in the master branch of https://codeberg.org/martianh/tumblesocks. I was under the impression that https://codeberg.org/martianh/tumblesocks was the new canonical repository, but I am wrong, am I not?

Let me know if you agree/disagree with those copyright messages. I'd like to see my changes appear in the offical elpa repository. Tell me if I have to change anything.

I already discovered some mistakes in my work and am already on version 1.1.5.  This pull request has all of my changes, including the fixes.